### PR TITLE
Fix vite base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     },
   },
   root: path.resolve(import.meta.dirname, "client"),
+  base: "./",
   build: {
     outDir: path.resolve(import.meta.dirname, "dist/public"),
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- add missing `base` to `vite.config.ts` so static files resolve correctly

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68615862a5348329a264a4d762b5aecb