### PR TITLE
Update Vite config for client root

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,20 +1,33 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import fs from "fs";
+
+const rootDir = path.resolve(__dirname, "client");
+const publicIndex = path.resolve(rootDir, "public", "index.html");
+const indexHtml = fs.existsSync(publicIndex)
+  ? publicIndex
+  : path.resolve(rootDir, "index.html");
+
 export default defineConfig({
+  root: rootDir,
   plugins: [react()],
   resolve: {
     alias: {
-      "@": path.resolve(import.meta.dirname, "src"),
-      "@shared": path.resolve(import.meta.dirname, "shared"),
-      "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+      "@": path.resolve(rootDir, "src"),
+      "@shared": path.resolve(__dirname, "shared"),
+      "@assets": path.resolve(__dirname, "attached_assets"),
     },
   },
   base: "./",
   build: {
-    outDir: path.resolve(import.meta.dirname, "dist"),
+    outDir: path.resolve(__dirname, "dist"),
     emptyOutDir: true,
+    rollupOptions: {
+      input: indexHtml,
+    },
   },
+  publicDir: path.resolve(rootDir, "public"),
   server: {
     fs: {
       strict: true,


### PR DESCRIPTION
## Summary
- rewrite `vite.config.ts` to use the `client` directory as root
- set alias `@` to `client/src`
- choose `client/public/index.html` if it exists

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686169e54e408329ba8b44796509612a