### PR TITLE
Add routes and links for management pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,12 +4,18 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import EmailGenerator from "@/pages/email-generator";
+import ClientsManagement from "@/pages/clients-management";
+import ProductsManagement from "@/pages/products-management";
+import CopywritersManagement from "@/pages/copywriters-management";
 import NotFound from "@/pages/not-found";
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={EmailGenerator} />
+      <Route path="/clients" component={ClientsManagement} />
+      <Route path="/products" component={ProductsManagement} />
+      <Route path="/copywriters" component={CopywritersManagement} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/pages/email-generator.tsx
+++ b/client/src/pages/email-generator.tsx
@@ -40,27 +40,24 @@ export default function EmailGenerator() {
                     <span>Generador</span>
                   </button>
                 </Link>
-                <button 
-                  onClick={() => alert("Panel de clientes próximamente")}
-                  className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium text-warm-gray hover:text-navy hover:bg-gray-100 transition-colors"
-                >
-                  <Users className="h-4 w-4" />
-                  <span>Clientes</span>
-                </button>
-                <button 
-                  onClick={() => alert("Panel de productos próximamente")}
-                  className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium text-warm-gray hover:text-navy hover:bg-gray-100 transition-colors"
-                >
-                  <Package className="h-4 w-4" />
-                  <span>Productos</span>
-                </button>
-                <button 
-                  onClick={() => alert("Panel de copywriters próximamente")}
-                  className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium text-warm-gray hover:text-navy hover:bg-gray-100 transition-colors"
-                >
-                  <PenTool className="h-4 w-4" />
-                  <span>Copywriters</span>
-                </button>
+                <Link href="/clients">
+                  <button className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium text-warm-gray hover:text-navy hover:bg-gray-100 transition-colors">
+                    <Users className="h-4 w-4" />
+                    <span>Clientes</span>
+                  </button>
+                </Link>
+                <Link href="/products">
+                  <button className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium text-warm-gray hover:text-navy hover:bg-gray-100 transition-colors">
+                    <Package className="h-4 w-4" />
+                    <span>Productos</span>
+                  </button>
+                </Link>
+                <Link href="/copywriters">
+                  <button className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium text-warm-gray hover:text-navy hover:bg-gray-100 transition-colors">
+                    <PenTool className="h-4 w-4" />
+                    <span>Copywriters</span>
+                  </button>
+                </Link>
               </nav>
               <div className="flex items-center space-x-2 text-sm text-warm-gray border-l border-gray-300 pl-4">
                 <Sparkles className="text-gold h-4 w-4" />


### PR DESCRIPTION
## Summary
- import management pages in App.tsx
- add routes for clients, products, and copywriters
- link to those pages from Email Generator page

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6861928b2dfc83298ede5d17015eb00f